### PR TITLE
Port to use latest version of libmagick

### DIFF
--- a/xwobf.c
+++ b/xwobf.c
@@ -26,7 +26,7 @@
 #include <getopt.h>
 #include <err.h>
 #include <xcb/xcb.h>
-#include <wand/MagickWand.h>
+#include <MagickWand/MagickWand.h>
 
 #include "xwobf.h"
 
@@ -191,14 +191,14 @@ void obscure_rectangle(rectangle_t *rec, int pixel_size, int fuzzy)
 
         // This is where the magick happens
         (void)MagickResizeImage(obs_wand, (rec->w)/pixel_size, (rec->h)/pixel_size,
-                PointFilter, 0);
+                PointFilter);
         if (fuzzy) {
                 (void)MagickBlurImage(obs_wand, 0, 1);
         }
         (void)MagickResizeImage(obs_wand, rec->w, rec->h,
-                PointFilter, 0);
+                PointFilter);
 
-        (void)MagickCompositeImage(wand, obs_wand, OverCompositeOp, rec->x, rec->y);
+        (void)MagickCompositeImage(wand, obs_wand, OverCompositeOp, MagickTrue, rec->x, rec->y);
 
         obs_wand = DestroyMagickWand(obs_wand);
     }


### PR DESCRIPTION
Wasn't sure if the maintainer wanted to stick with libmagick6, but here's a port to the newer version. Could just stick this in a new branch for people who didn't want to install libmagick6 just for this. 

Tested on: Arch Linux